### PR TITLE
fix: rename the codegen script to script/Build.sol

### DIFF
--- a/script/Build.sol
+++ b/script/Build.sol
@@ -10,7 +10,7 @@ import {LibGenParseMeta} from "rain-interpreter-interface-0.1.0/src/lib/codegen/
 import {LibMerkleSubParser} from "src/lib/parse/LibMerkleSubParser.sol";
 import {PARSE_META_BUILD_DEPTH} from "src/abstract/MerkleSubParser.sol";
 
-contract BuildPointers is Script {
+contract Build is Script {
     function buildMerkleWordsPointers() internal {
         MerkleWords merkleWords = new MerkleWords();
 


### PR DESCRIPTION
rainlanguage/rainix#272 (merged, `ef89e90`) made `rainix-copy-artifacts` require the codegen script to be `script/Build.sol`, matched exactly. This repo's script is `script/BuildPointers.sol`, so its `copy-artifacts` job now **errors** until renamed.

That guard replaced an `if: hashFiles('script/BuildPointers.sol')` gate whose failure mode was worse than a red: a repo whose script didn't match that exact name had regeneration **silently skipped**, and the "committed artifacts match freshly built" assert then passed having regenerated nothing — a green over an unchecked tree.

## Change

- `script/BuildPointers.sol` -> `script/Build.sol`, `contract BuildPointers` -> `contract Build`.
- References to the script updated (docs, comments, and any invocation).

The generated `src/generated/*.pointers.sol` files are deliberately **untouched**. Their `AUTOGENERATED BY ./script/BuildPointers.sol` header is emitted by this repo's pinned `rain-sol-codegen`, which still writes that name, so regeneration reproduces them byte-for-byte and `copy-artifacts` stays green. The header and the `.pointers.sol` suffix change when this repo bumps to codegen 0.1.4+ (rainlanguage/rain.sol.codegen#31), which is separate work.

The name: the generated file is a set of constants for a contract, and only the interpreter/word repos generate an actual function pointer table — so "pointers" named the exception rather than the thing.
