### PR TITLE
Remove submodule-era residue: dead REUSE.toml annotations and dead lib/rain.interpreter workflow steps

### DIFF
--- a/.github/workflows/manual-sol-artifacts.yaml
+++ b/.github/workflows/manual-sol-artifacts.yaml
@@ -48,13 +48,6 @@ jobs:
           gc-max-store-size-linux: 1G
 
       - run: nix develop -c rainix-sol-prelude
-        working-directory: ./lib/rain.interpreter
-      - run: nix develop -c rainix-rs-prelude
-        working-directory: ./lib/rain.interpreter
-      - run: nix develop -c i9r-prelude
-        working-directory: ./lib/rain.interpreter
-
-      - run: nix develop -c rainix-sol-prelude
 
       - run: nix develop -c rainix-sol-artifacts
         env:

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -6,7 +6,6 @@ path = [
     ".github/workflows/**/",
     "meta/**/",
     ".gitignore",
-    ".gitmodules",
     "audit/**/",
     "README.md",
     "flake.lock",
@@ -19,7 +18,6 @@ path = [
     "package-lock.json",
     "package.json",
     "test/proof/**/",
-    "foundry.lock",
 ]
 SPDX-FileCopyrightText = "Copyright (c) 2020 Rain Open Source Software Ltd"
 SPDX-License-Identifier = "LicenseRef-DCL-1.0"


### PR DESCRIPTION
Closes https://github.com/rainlanguage/rain.merkle/issues/17

## What this removes

`599ba7b` ("chore: de-submodule to soldeer + modernize CI") deleted this repo's only submodule — `lib/rain.interpreter` — along with `.gitmodules` and `foundry.lock`. Three references to that era were left behind. This removes all three.

### `REUSE.toml`

- line 9, `".gitmodules",`
- line 22, `"foundry.lock",`

Neither file exists. `git ls-files --stage | grep ^160000` is empty, `foundry.toml` sets `libs = ["node_modules", "dependencies"]`, `soldeer.lock` is the live lockfile, and there is no `lib/`. `foundry.lock` is Foundry's **git submodule** lockfile and is meaningless in a soldeer repo.

Neither path can come back: rainix CI runs [`no-submodules`](https://github.com/rainlanguage/rainix/blob/main/.github/actions/no-submodules/action.yml), which fails on a root `.gitmodules` or any committed gitlink.

### `.github/workflows/manual-sol-artifacts.yaml`

```yaml
      - run: nix develop -c rainix-sol-prelude
        working-directory: ./lib/rain.interpreter
      - run: nix develop -c rainix-rs-prelude
        working-directory: ./lib/rain.interpreter
      - run: nix develop -c i9r-prelude
        working-directory: ./lib/rain.interpreter
```

`./lib/rain.interpreter` has not existed since `599ba7b`. `actions/checkout@v4` runs without submodules, so the directory is never created and each of these three steps can only fail with a chdir error — the whole `Manual sol artifacts` workflow is dead today. The repo's own `rainix-sol-prelude`, on the line immediately below, is the live one and is untouched.

The issue body asserted `.github/workflows/` was clean. It is not — this is the same residue from the same commit, and the issue's own "Done when" requires that no `lib/` reference remain outside `dependencies/`, so it is in scope rather than a widening.

## Verification

`git grep -E '\.gitmodules|foundry\.lock|(^|[^a-zA-Z0-9_./-])lib/' -- . ':!dependencies'` returns nothing after this change.

Full rainix suite run locally against the pinned CI shell (`rainix@53e96a7`):

| job | check | result |
| --- | --- | --- |
| `legal` | `reuse lint` | pass — 33/33 files, REUSE 3.3 compliant |
| `static` | `forge fmt --check` | pass |
| `static` | `rainix-sol-single-contract` | pass |
| `static` | `slither .` | pass — 60 contracts, 98 detectors, 0 results |
| `test` | `forge test -vvv` | pass — 12 tests, 0 failed |
| `git-clean` | `forge script Build.sol` + `forge build` + `script/build.sh` + `forge fmt` + `git diff --exit-code` | pass |

`reuse lint` tolerates annotation paths that do not exist — which is why these two survived the `foundry.lock` deletion and why `legal` was green before this change as well as after.

## QA

- Discriminating tests: n/a — this is a pure deletion of dead metadata. Nothing here is reachable by a Solidity test: `REUSE.toml` is read only by `reuse lint`, and `manual-sol-artifacts.yaml` is a `workflow_dispatch`-only deploy workflow. The oracle for both is the filesystem, not the test suite. The full existing suite (12 tests) still passes unchanged, confirming no collateral effect.
- Mutations applied: n/a — no executable source line changed. `src/`, `script/`, `test/` and `foundry.toml` are untouched; the diff is 9 deleted lines across one TOML file and one YAML file. There is no line whose behavior a mutation could discriminate.
- Oracle: the repository tree itself, read independently of the annotations. `git ls-files --stage | grep ^160000` returns nothing (zero gitlinks), `ls` shows no `.gitmodules`, no `foundry.lock` and no `lib/`, and `git log -1 -- .gitmodules` pins the deletion to `599ba7b` with `git show 599ba7b^:.gitmodules` naming `lib/rain.interpreter` as the only submodule that ever existed. Each removed path was checked against the tree, not against the issue's description of the tree — which is how the third reference (the workflow) was found. Post-change, `git grep -E '\.gitmodules|foundry\.lock|(^|[^a-zA-Z0-9_./-])lib/' -- . ':!dependencies'` is empty, and `reuse lint` reports 33/33 files covered, so no live path lost its annotation.
- Category check: issue asks (a) `REUSE.toml` line 9 `.gitmodules`, (b) `REUSE.toml` line 22 `foundry.lock`, (c) no reference to `.gitmodules`, `lib/` or `foundry.lock` anywhere outside `dependencies/`, (d) CI green. Covered a, b, c, d. (c) is the category the issue's own examples under-enumerate: its prose claims `.github/workflows/` was grepped clean, but `manual-sol-artifacts.yaml` carries three `working-directory: ./lib/rain.interpreter` steps from the same commit. Covering the stated property rather than the two stated line numbers is what closes (c) honestly. Checked the sibling repos — none of `rain.verify`, `rain.flare`, `rain.dia`, `rain.erc4626.words`, `rain.string`, `rain.solmem` has a `working-directory` in that workflow, so removal matches the org shape rather than inventing one.

## Out of scope

The eight repos that still carry a `foundry.lock`, and the further 17 rainlanguage repos with the same residue, each have their own issue. `flow` and `rain.tier.interface` genuinely still use git submodules and are correct as they stand.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined the manual Solidity artifact workflow by removing obsolete setup steps.
  * Updated project reuse annotation configuration to exclude legacy metadata files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->